### PR TITLE
Cold-read fixes (notation examples, CONST/CMOV, rendering)

### DIFF
--- a/draft-irtf-cfrg-cryptography-specification.md
+++ b/draft-irtf-cfrg-cryptography-specification.md
@@ -355,10 +355,13 @@ When pseudocode requires constant-time behavior, mark the line with the
 z <- CMOV(x, y, e)  # CONST: branch-free
 ~~~~
 
-Such annotations state intent; they do not by themselves make an
-implementation constant-time.  Specifications should also identify which
-values are secret, so that implementations avoid branching on, or
-indexing memory by, secret-derived values.
+The `CONST` tag and the CMOV function above are an illustrative
+convention used in this document, not a standardized notation; a
+specification that adopts a similar marker SHOULD define it explicitly
+in its own Notation section.  Such annotations state intent; they do not
+by themselves make an implementation constant-time.  Specifications
+should also identify which values are secret, so that implementations
+avoid branching on, or indexing memory by, secret-derived values.
 
 
 #### Visual Representations
@@ -398,8 +401,8 @@ particular, authors MUST NOT use `^` for both XOR and exponentiation.
 When a Unicode symbol is used, the specification SHOULD provide an ASCII
 or function-style equivalent at first use, and SHOULD give the Unicode
 code point or character name for less common, visually confusable, or
-domain-specific symbols.  For example, `⊕` can be introduced as `⊕`
-(XOR, U+2295) and `∥` as concatenation (`||`).
+domain-specific symbols.  For example, `⊕` can be introduced as XOR
+(`⊕`, U+2295) and `∥` can be introduced as concatenation (`||`).
 
 Formatting MUST NOT be required to recover the meaning of an algorithm.
 Superscripts, font choice, glyph shape, or rendering differences across


### PR DESCRIPTION
Addresses the crypto-spec findings from the pre-submission cold read
(2026-07-06).  Two unambiguous editorial/internal-consistency fixes
applied; two items verified and left as-is with rationale; one item
flagged for author confirmation.

## Applied

- Self-referential Unicode example (Mathematical Notation and
  Unicode section): the example introduced the XOR symbol using
  itself ("can be introduced as `⊕` (XOR, U+2295)"), which is
  exactly the failure mode the surrounding SHOULD-provide-an-ASCII-
  equivalent-at-first-use rule warns against.  Now shows the ASCII
  term XOR as the introducing text, with the Unicode symbol and its
  code point following.

- CONST/CMOV convention: added an explicit statement that the
  `CONST` tag and the CMOV function used in the pseudocode example
  are this document's own illustrative convention, not a
  standardized notation, and that a specification adopting a
  similar marker SHOULD define it in its own Notation section.

## Verified, no change made

- `||` concatenation table row: confirmed it renders correctly in
  both the generated .txt and .html.  The `||` and `M1 || M2` cells
  are inside backtick code spans, which kramdown parses before
  splitting the row on `|`, so there is no column-delimiter
  collision.  No fix needed.

- RFC 7748 `^`-overload caveat: previously verified against RFC
  7748 (line 464 `swap ^= k_t` is XOR, line 471 `A^2` is
  exponentiation).  Left unchanged, as instructed.

- Sampling operator naming: the draft defines exactly one canonical
  sampling operator, `<-$` (Notation table, "Random sampling" row).
  `randbits(n)` earlier in the section is offered only as an example
  of function-style notation in general (alongside `xor(a, b)` and
  `concat(a, b)`), not as a competing definition of the sampling
  operator, and "sampling notation" in the author checklist is a
  generic category label pointing at whatever symbol the Notation
  table defines.  No internal contradiction for the text to resolve;
  left unchanged.

## Flagged for author verification (no change made)

- RFC 8032 erratum description (Test Vectors section, "Examples of
  Specifications That Could Be Improved"): the current text
  describes Errata ID 5968 as a verification-comparison fix, "a
  `greater than` that should have been a `greater than or equal
  to`."  The published erratum
  (https://www.rfc-editor.org/errata/eid5968, Status: Verified)
  is a Section 3.1 scalar-encoding range fix: `0 < S < L - 1`
  corrected to `0 <= S <= L - 1` (endpoint inclusion), not a
  comparison-operator change in verification.  This looks inverted
  and should probably be corrected to describe the actual erratum,
  but it is a factual claim about a third-party document rather
  than an internal-consistency issue, so it is left for author
  confirmation rather than applied here.

## Not touched (per review scope)

- Document category (`info`) and RFC 2119 boilerplate/keyword
  casing: author decision, out of scope for this pass.
- Exponentiation operator-table row (`^ or **`): author has
  deliberately kept both symbols; not removed.

## Verification

- `make` clean: kramdown-rfc OK, xml2rfc-txt OK, xml2rfc-html OK, no
  warnings.
- No lines over 72 columns outside exempt table rows.
- Edits applied via the spec-edit harness (single-match assertion,
  re-wrap, em-dash refusal, build gate).
